### PR TITLE
Target cluster stats only for cluster summary

### DIFF
--- a/var_lib_grafana/dashboards/Weka_Cluster_Overview.json
+++ b/var_lib_grafana/dashboards/Weka_Cluster_Overview.json
@@ -2054,7 +2054,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (host_name) (weka_stats{cluster=\"$cluster\",stat=\"CPU_UTILIZATION\",node_role=\"FRONTEND\"})",
+          "expr": "avg by (host_name) (weka_stats{cluster=\"$cluster\",stat=\"CPU_UTILIZATION\",node_role=\"FRONTEND\",host_role=\"server\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{host_name}}",


### PR DESCRIPTION
Before this change, this would also pull in CPU stats for all stateful clients, as well as the server.